### PR TITLE
Release confluent-connect 1.0.0-3.2.2 (automated commit)



### DIFF
--- a/repo/packages/C/confluent-connect/9/config.json
+++ b/repo/packages/C/confluent-connect/9/config.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "connect": {
+      "properties": {
+        "name": {
+          "default": "connect",
+          "description": "Service name for the connect worker application(s)",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each connect worker instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024,
+          "description": "Memory (MB) to allocate to each connect worker instance.",
+          "minimum": 512,
+          "type": "number"
+        },
+        "heap": {
+          "default": 768,
+          "description": "JVM heap allocation (in MB) for connect worker task; should be ~256MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy connect worker only on nodes with this role.",
+          "type": "string"
+        },
+        "kafka-service": {
+          "default": "confluent-kafka",
+          "description": "Target Apache Kafka by Confluent service to which these tasks will connect. ",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "master.mesos:2181/dcos-service-confluent-kafka",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        },
+        "schema-registry-service": {
+          "default": "schema-registry",
+          "description": "Schema Registry service to be used by connect workers. The named VIP associated with this service will be used to specify the converter-schema-registry-url's",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "instances",
+        "name"
+      ],
+      "type": "object"
+    },
+    "hdfs": {
+      "description": "Connect-HDFS configuration properties",
+      "type": "object",
+      "properties": {
+        "config-url": {
+          "type": "string",
+          "description": "Base URL that serves HDFS config files (hdfs-site.xml, core-site.xml).  If not set, DCOS Connect will use its default configuration and read from DCOS HDFS."
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-connect/9/marathon.json.mustache
+++ b/repo/packages/C/confluent-connect/9/marathon.json.mustache
@@ -1,0 +1,79 @@
+{
+  "id": "/{{connect.name}}",
+  "instances": {{connect.instances}},
+  "cpus": {{connect.cpus}},
+  "mem": {{connect.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 8083,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{connect.name}}:8083"
+          }
+      } ]
+    }
+  },
+  "portDefinitions": [ {
+    "name": "{{connect.name}}",
+    "port": 8083,
+    "protocol": "tcp",
+    "labels": {
+      "VIP_0": "{{connect.name}}:8083"
+    }
+  } ],
+  "env": {
+    "CONNECT_BOOTSTRAP_SERVERS": "broker.{{connect.kafka-service}}.l4lb.thisdcos.directory:9092",
+    "CONNECT_REST_PORT": "8083",
+    "CONNECT_GROUP_ID": "dcos-{{connect.name}}-group",
+    "CONNECT_CONFIG_STORAGE_TOPIC": "dcos-{{connect.name}}-configs",
+    "CONNECT_OFFSET_STORAGE_TOPIC": "dcos-{{connect.name}}-offsets",
+    "CONNECT_STATUS_STORAGE_TOPIC": "dcos-{{connect.name}}-status",
+	"CONNECT_KEY_CONVERTER" : "io.confluent.connect.avro.AvroConverter",
+    "CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL": "http://{{connect.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081",
+	"CONNECT_VALUE_CONVERTER" : "io.confluent.connect.avro.AvroConverter",
+    "CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL": "http://{{connect.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081",
+	"CONNECT_INTERNAL_KEY_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+	"CONNECT_INTERNAL_VALUE_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+    "CONNECT_PRODUCER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor",
+    "CONNECT_CONSUMER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor",
+    "CONNECT_ZOOKEEPER_CONNECT": "{{connect.zookeeper-connect}}",
+    "CONNECT_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
+    "KAFKA_HEAP_OPTS": "-Xmx{{connect.heap}}M"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{connect.role}}"
+  ],
+  "labels": {
+{{#hdfs.config-url}}
+        "SPARK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
+{{/hdfs.config-url}}
+    "DCOS_SERVICE_NAME": "{{connect.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  "uris": [
+   {{#hdfs.config-url}}
+    "{{hdfs.config-url}}/hdfs-site.xml",
+    "{{hdfs.config-url}}/core-site.xml"
+    {{/hdfs.config-url}}
+  ]
+}

--- a/repo/packages/C/confluent-connect/9/package.json
+++ b/repo/packages/C/confluent-connect/9/package.json
@@ -1,0 +1,23 @@
+{
+    "packagingVersion": "3.0",
+    "name": "confluent-connect",
+    "version": "1.0.0-3.2.2",
+    "scm": "https://github.com/confluentinc/kafka",
+    "description": "Confluent Connect worker\n\n\tDocumentation: http://docs.confluent.io/3.2.2/connect/managing.html",
+    "maintainer": "partner-support@confluent.io",
+    "tags": [
+        "kafka",
+        "confluent",
+        "connect"
+    ],
+    "preInstallNotes": "This DC/OS Service is currently in preview. Preparing to install confluent-connect",
+    "postInstallNotes": "confluent-connect has been installed.",
+    "postUninstallNotes": "confluent-connect was uninstalled successfully.",
+    "minDcosReleaseVersion": "1.8",
+    "licenses": [
+        {
+            "name": "Apache License v2",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    ]
+}

--- a/repo/packages/C/confluent-connect/9/resource.json
+++ b/repo/packages/C/confluent-connect/9/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "lightbend/cp-kafka-connect:3.2.2"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}


### PR DESCRIPTION
Release confluent-connect 1.0.0-3.2.2 (automated commit)

Description:
Release confluent-connect, FDP, test PR

Source URL: https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/confluent-connect/20170909-111247-kjZYJaKJo4ZTajEI/stub-universe-confluent-connect.json

Changes since revision 8:
0 files added: []
0 files removed: []
4 files changed:

```
--- 8/config.json
+++ 9/config.json
@@ -50,12 +50,26 @@
         "schema-registry-service": {
           "default": "schema-registry",
           "description": "Schema Registry service to be used by connect workers. The named VIP associated with this service will be used to specify the converter-schema-registry-url's",
-
           "type": "string"
         }
       },
-      "required": ["cpus", "mem", "instances", "name"],
+      "required": [
+        "cpus",
+        "mem",
+        "instances",
+        "name"
+      ],
       "type": "object"
+    },
+    "hdfs": {
+      "description": "Connect-HDFS configuration properties",
+      "type": "object",
+      "properties": {
+        "config-url": {
+          "type": "string",
+          "description": "Base URL that serves HDFS config files (hdfs-site.xml, core-site.xml).  If not set, DCOS Connect will use its default configuration and read from DCOS HDFS."
+        }
+      }
     }
   },
   "type": "object"
--- 8/marathon.json.mustache
+++ 9/marathon.json.mustache
@@ -44,6 +44,7 @@
     "CONNECT_PRODUCER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor",
     "CONNECT_CONSUMER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor",
     "CONNECT_ZOOKEEPER_CONNECT": "{{connect.zookeeper-connect}}",
+    "CONNECT_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
     "KAFKA_HEAP_OPTS": "-Xmx{{connect.heap}}M"
   },
   "healthChecks": [
@@ -62,8 +63,17 @@
     "{{connect.role}}"
   ],
   "labels": {
+{{#hdfs.config-url}}
+        "SPARK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
+{{/hdfs.config-url}}
     "DCOS_SERVICE_NAME": "{{connect.name}}",
     "DCOS_SERVICE_SCHEME": "http",
     "DCOS_SERVICE_PORT_INDEX": "0"
-  }
+  },
+  "uris": [
+   {{#hdfs.config-url}}
+    "{{hdfs.config-url}}/hdfs-site.xml",
+    "{{hdfs.config-url}}/core-site.xml"
+    {{/hdfs.config-url}}
+  ]
 }
--- 8/package.json
+++ 9/package.json
@@ -1,19 +1,23 @@
 {
-  "packagingVersion": "3.0",
-  "name": "confluent-connect",
-  "version": "1.0.0-3.3.0",
-  "scm": "https://github.com/confluentinc/kafka",
-  "description": "Confluent Connect worker\n\n\tDocumentation: http://docs.confluent.io/3.3.0/connect/managing.html",
-  "maintainer": "partner-support@confluent.io",
-  "tags": ["kafka", "confluent", "connect"],
-  "preInstallNotes": "This DC/OS Service is currently in preview. Preparing to install confluent-connect",
-  "postInstallNotes": "confluent-connect has been installed.",
-  "postUninstallNotes": "confluent-connect was uninstalled successfully.",
-  "minDcosReleaseVersion" : "1.8",
-  "licenses": [
-    {
-      "name": "Apache License v2",
-      "url": "https://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ]
+    "packagingVersion": "3.0",
+    "name": "confluent-connect",
+    "version": "1.0.0-3.2.2",
+    "scm": "https://github.com/confluentinc/kafka",
+    "description": "Confluent Connect worker\n\n\tDocumentation: http://docs.confluent.io/3.2.2/connect/managing.html",
+    "maintainer": "partner-support@confluent.io",
+    "tags": [
+        "kafka",
+        "confluent",
+        "connect"
+    ],
+    "preInstallNotes": "This DC/OS Service is currently in preview. Preparing to install confluent-connect",
+    "postInstallNotes": "confluent-connect has been installed.",
+    "postUninstallNotes": "confluent-connect was uninstalled successfully.",
+    "minDcosReleaseVersion": "1.8",
+    "licenses": [
+        {
+            "name": "Apache License v2",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    ]
 }
--- 8/resource.json
+++ 9/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-kafka-connect:3.3.0"
+        "image": "lightbend/cp-kafka-connect:3.2.2"
       }
     }
   },
```
